### PR TITLE
Add (extremely) basic Github Actions for Linux development

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -1,0 +1,42 @@
+on:
+  push:
+    branches:
+      - main
+
+env:
+  PYTHONIOENCODING: utf-8
+  PYTHONLEGACYWINDOWSSTDIO: utf-8
+
+jobs:
+  check-ubuntu-x86_64:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04]
+    steps:
+    - name: Checkout git repo
+      uses: actions/checkout@v2
+      with:
+        path: main
+    - name: Preparations
+      working-directory: main
+      run: |
+        # The 'submodules' option for actions/checkout@v2 doesn't
+        # seem to work. So we manually sync it just in case.
+        git submodule init
+        git submodule update
+        sudo apt update
+        sudo apt install -y cmake ninja-build g++
+        mkdir -p cmake-build-release
+    - name: Configuring CMake
+      working-directory: main/cmake-build-release
+      run: |
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Release ../
+    - name: Build
+      working-directory: main/cmake-build-release
+      run: |
+        ninja all
+    - name: Test
+      working-directory: main/cmake-build-release
+      run: |
+        ninja test

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,13 +1,13 @@
 [submodule "3rd/Catch2"]
 	path = 3rd/Catch2
-	url = git@github.com:catchorg/Catch2.git
+	url = https://github.com/catchorg/Catch2.git
 	branch = v2.x
 [submodule "3rd/utfcpp"]
 	path = 3rd/utfcpp
-	url = git@github.com:nemtrif/utfcpp.git
+	url = https://github.com/nemtrif/utfcpp.git
 [submodule "runtime/raylib"]
 	path = runtime/raylib
-	url = git@github.com:raysan5/raylib.git
+	url = https://github.com/raysan5/raylib.git
 [submodule "runtime/raygui"]
 	path = runtime/raygui
-	url = git@github.com:raysan5/raygui.git
+	url = https://github.com/raysan5/raygui.git


### PR DESCRIPTION
This action will build and test on Ubuntu LTS versions upon a git push. I've locally tested this workflow using [nektos/act](https://github.com/nektos/act). Despite the fact that the Ubuntu 22.04 configuration kept failing locally with weird messages while 20.04 worked just fine, I believe the issue was due to some problems of my local docker. So I thought we might want to give it a try and remove the 22.04 config it that doesn't work out.

Note that I also changed all the submodule path from using ssh to using https, so that CI will have an easier time to pull them without any tokens or keys.