### PR TITLE
Feature/fix macos carpntr

### DIFF
--- a/compiler/carpntr/building.yaka
+++ b/compiler/carpntr/building.yaka
@@ -321,10 +321,10 @@ def create_args(c: carp.Config, code_path: str, build_path: str, target: str, ra
     if target == "wasm4":
         arrput(args, "-target")
         arrput(args, "wasm32-wasi-musl")
-    # m1/m2/etc must not build for native, instead build for "aarch64-macos-gnu"
+    # m1/m2/etc must not build for native, instead build for "aarch64-macos-none"
     if native and is_arm64_cpu() and is_target_macos(target) and not c.use_alt_compiler:
         arrput(args, "-target")
-        arrput(args, "aarch64-macos-gnu")
+        arrput(args, "aarch64-macos-none")
     # runtime c codes
     length = len(c.c_code.runtime_feature_c_code)
     x = 0

--- a/compiler/carpntr/main.yaka.c
+++ b/compiler/carpntr/main.yaka.c
@@ -1481,7 +1481,7 @@ yk__sds* yy__building_create_args(struct yy__configuration_Config* yy__building_
     if (((yy__building_native && yy__building_is_arm64_cpu()) && yy__building_is_target_macos(yk__sdsdup(yy__building_target))) && (!(yy__building_c->yy__configuration_use_alt_compiler)))
     {
         yk__arrput(yy__building_args, yk__sdsnewlen("-target", 7));
-        yk__arrput(yy__building_args, yk__sdsnewlen("aarch64-macos-gnu", 17));
+        yk__arrput(yy__building_args, yk__sdsnewlen("aarch64-macos-none", 17));
     }
     yy__building_length = yk__arrlen(yy__building_c->yy__configuration_c_code->yy__configuration_runtime_feature_c_code);
     yy__building_x = INT32_C(0);

--- a/compiler/carpntr/main.yaka.c
+++ b/compiler/carpntr/main.yaka.c
@@ -1481,7 +1481,7 @@ yk__sds* yy__building_create_args(struct yy__configuration_Config* yy__building_
     if (((yy__building_native && yy__building_is_arm64_cpu()) && yy__building_is_target_macos(yk__sdsdup(yy__building_target))) && (!(yy__building_c->yy__configuration_use_alt_compiler)))
     {
         yk__arrput(yy__building_args, yk__sdsnewlen("-target", 7));
-        yk__arrput(yy__building_args, yk__sdsnewlen("aarch64-macos-none", 17));
+        yk__arrput(yy__building_args, yk__sdsnewlen("aarch64-macos-none", 18));
     }
     yy__building_length = yk__arrlen(yy__building_c->yy__configuration_c_code->yy__configuration_runtime_feature_c_code);
     yy__building_x = INT32_C(0);

--- a/compiler/carpntr/yaksha.toml
+++ b/compiler/carpntr/yaksha.toml
@@ -22,4 +22,4 @@ libc="try_musl"
 # Automatically use zig cc & zig c++ to build project
 # We will start with just zig cc, zig c++ support so this is ignored for now
 compiler="zig"
-targets=["x86_64-linux-musl", "x86_64-linux-gnu", "x86_64-windows-gnu", "aarch64-macos-gnu", "x86_64-macos-gnu"]
+targets=["x86_64-linux-musl", "x86_64-linux-gnu", "x86_64-windows-gnu", "aarch64-macos-none", "x86_64-macos-none"]

--- a/compiler/hammer.toml
+++ b/compiler/hammer.toml
@@ -13,7 +13,7 @@
 # Note that all the paths are relative in current directory
 #
 [compilation]
-targets=["x86_64-linux-musl", "x86_64-linux-gnu", "x86_64-windows-gnu", "aarch64-macos-gnu", "x86_64-macos-gnu"]
+targets=["x86_64-linux-musl", "x86_64-linux-gnu", "x86_64-windows-gnu", "aarch64-macos-none", "x86_64-macos-none"]
 args_c_or_cpp=["-O2", "-fPIC"]
 args_cpp=["-std=c++17"]
 args_c=["-std=c99"]

--- a/compiler/hammer/main.yaka
+++ b/compiler/hammer/main.yaka
@@ -131,10 +131,10 @@ def get_base_args(c: conf.HammerConfig, target: str, cpp: bool) -> Array[str]:
     if not (target == "native"):
         arrput(args, "-target")
         arrput(args, target)
-    # m1/m2/etc must not build for native, instead build for "aarch64-macos-gnu"
+    # m1/m2/etc must not build for native, instead build for "aarch64-macos-none"
     if target == "native" and is_arm64_cpu() and is_target_macos(target):
         arrput(args, "-target")
-        arrput(args, "aarch64-macos-gnu")
+        arrput(args, "aarch64-macos-none")
     args = sarr.extend(args, c.args_c_or_cpp)
     if cpp:
         args = sarr.extend(args, c.args_cpp)

--- a/compiler/hammer/yaksha.toml
+++ b/compiler/hammer/yaksha.toml
@@ -22,4 +22,4 @@ libc="try_musl"
 # Automatically use zig cc & zig c++ to build project
 # We will start with just zig cc, zig c++ support so this is ignored for now
 compiler="zig"
-targets=["aarch64-linux-musl", "aarch64-macos-gnu", "i386-linux-musl", "i386-windows-gnu", "x86_64-linux-musl", "x86_64-linux-gnu", "x86_64-windows-gnu", "x86_64-macos-gnu"]
+targets=["aarch64-linux-musl", "aarch64-macos-none", "i386-linux-musl", "i386-windows-gnu", "x86_64-linux-musl", "x86_64-linux-gnu", "x86_64-windows-gnu", "x86_64-macos-none"]

--- a/compiler/scripts/release.ini
+++ b/compiler/scripts/release.ini
@@ -40,9 +40,9 @@ zig_sha256=8c473082b4f0f819f1da05de2dbd0c1e891dff7d85d2c12b6ee876887d438287
 zig_subfolder=zig-macos-aarch64-0.9.1
 exe_suffix=
 binaries=["yaksha", "carpntr", "hammer"]
-bin__yaksha=["bin/hammer.bin/yaksha-aarch64-macos-gnu"]
-bin__carpntr=["carpntr/build/carpntr-aarch64-macos-gnu"]
-bin__hammer=["hammer/build/hammer-aarch64-macos-gnu"]
+bin__yaksha=["bin/hammer.bin/yaksha-aarch64-macos-none"]
+bin__carpntr=["carpntr/build/carpntr-aarch64-macos-none"]
+bin__hammer=["hammer/build/hammer-aarch64-macos-none"]
 
 [macos-x86_64]
 zig=https://ziglang.org/download/0.9.1/zig-macos-x86_64-0.9.1.tar.xz
@@ -50,9 +50,9 @@ zig_sha256=2d94984972d67292b55c1eb1c00de46580e9916575d083003546e9a01166754c
 zig_subfolder=zig-macos-x86_64-0.9.1
 exe_suffix=
 binaries=["yaksha", "carpntr", "hammer"]
-bin__yaksha=["bin/hammer.bin/yaksha-x86_64-macos-gnu"]
-bin__carpntr=["carpntr/build/carpntr-x86_64-macos-gnu"]
-bin__hammer=["hammer/build/hammer-x86_64-macos-gnu"]
+bin__yaksha=["bin/hammer.bin/yaksha-x86_64-macos-none"]
+bin__carpntr=["carpntr/build/carpntr-x86_64-macos-none"]
+bin__hammer=["hammer/build/hammer-x86_64-macos-none"]
 
 [common]
 folders=["runtime", "libs"]


### PR DESCRIPTION
Change target from -gnu to -none for macOS in Zig build

macOS no longer supports GNU libc (glibc) as its system libc and uses its own Darwin libc. The previous target with -gnu libc is incompatible and causes errors due to missing or unsupported GNU libc. Switching to -none aligns the target with macOS's native libc, ensuring proper libc support and successful Zig builds on aarch64 macOS versions. This change improves compatibility and resolves libc-related build errors.

Error message:

`error: unable to find or provide libc for target 'aarch64-macos.13.0...15.3.1-gnu'
info: zig can provide libc for related target aarch64-macos.11.0.0-none`

After changing:

`
native := done.
x86_64-linux-musl := done.
x86_64-linux-gnu := done.
x86_64-windows-gnu := done.
aarch64-macos-none := done.
x86_64-macos-none := done.
`