### PR TITLE
Improve image alt text and clarify license exception wording in README

### DIFF
--- a/compiler/README.md
+++ b/compiler/README.md
@@ -2,7 +2,7 @@
 
 ---------
 
-![https://yakshalang.github.io/](https://yakshalang.github.io/imgs/yk-banner1.png)
+![Yaksha Language Banner](https://yakshalang.github.io/imgs/yk-banner1.png)
 
 ---------
 ```text
@@ -33,7 +33,8 @@
  Additional Terms:
 
  Please note that any commercial use of the programming language's compiler source code
- (everything except compiler/runtime, compiler/libs and compiler/3rd) require a written agreement
+ (everything except files in compiler/runtime, compiler/libs, and compiler/3rd)
+ require a written agreement
  with author of the language (Bhathiya Perera).
 
  If you are using it for an open source project, please give credits.


### PR DESCRIPTION
- Improved the image alt text for accessibility by changing it from a URL to a descriptive phrase.
- Clarified the license exception wording for better readability.